### PR TITLE
Add Dark Theme Support and Core Palette to Blogify App

### DIFF
--- a/lib/core/theme/app_pallete.dart
+++ b/lib/core/theme/app_pallete.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class AppPallete {
+  static const Color backgroundColor = Color.fromRGBO(24, 24, 32, 1);
+  static const Color gradient1 = Color.fromRGBO(187, 63, 221, 1);
+  static const Color gradient2 = Color.fromRGBO(251, 109, 169, 1);
+  static const Color gradient3 = Color.fromRGBO(255, 159, 124, 1);
+  static const Color borderColor = Color.fromRGBO(52, 51, 67, 1);
+  static const Color whiteColor = Colors.white;
+  static const Color greyColor = Colors.grey;
+  static const Color errorColor = Colors.redAccent;
+  static const Color transparentColor = Colors.transparent;
+}

--- a/lib/core/theme/theme.dart
+++ b/lib/core/theme/theme.dart
@@ -1,0 +1,31 @@
+import 'package:blogify/core/theme/app_pallete.dart';
+import 'package:flutter/material.dart';
+
+class AppTheme {
+  static _border([Color color = AppPallete.borderColor]) => OutlineInputBorder(
+        borderSide: BorderSide(
+          color: color,
+          width: 3,
+        ),
+        borderRadius: BorderRadius.circular(10),
+      );
+  static final darkThemeMode = ThemeData.dark().copyWith(
+    scaffoldBackgroundColor: AppPallete.backgroundColor,
+    appBarTheme: const AppBarTheme(
+      backgroundColor: AppPallete.backgroundColor,
+    ),
+    chipTheme: const ChipThemeData(
+      color: MaterialStatePropertyAll(
+        AppPallete.backgroundColor,
+      ),
+      side: BorderSide.none,
+    ),
+    inputDecorationTheme: InputDecorationTheme(
+      contentPadding: const EdgeInsets.all(27),
+      border: _border(),
+      enabledBorder: _border(),
+      focusedBorder: _border(AppPallete.gradient2),
+      errorBorder: _border(AppPallete.errorColor),
+    ),
+  );
+}


### PR DESCRIPTION
- Added a new `AppPallete` class in the `core/theme` folder, defining the core colors for the Blogify app.
  - Defined colors: `backgroundColor`, `gradient1`, `gradient2`, `gradient3`, `borderColor`, `whiteColor`, `greyColor`, `errorColor`, and `transparentColor`.
- Implemented a `darkThemeMode` in the `AppTheme` class to provide a consistent dark theme throughout the app.
  - Custom `InputDecorationTheme` with modified borders and padding.
  - Updated `scaffoldBackgroundColor` and `appBarTheme` to align with the dark theme.
- Ready for review and merge into the main branch.
