### PR TITLE
Merge Auth Sign-Up UI and Widgets to Main

### DIFF
--- a/lib/core/theme/app_pallete.dart
+++ b/lib/core/theme/app_pallete.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class AppPallete {
+  static const Color backgroundColor = Color.fromRGBO(24, 24, 32, 1);
+  static const Color gradient1 = Color.fromRGBO(187, 63, 221, 1);
+  static const Color gradient2 = Color.fromRGBO(251, 109, 169, 1);
+  static const Color gradient3 = Color.fromRGBO(255, 159, 124, 1);
+  static const Color borderColor = Color.fromRGBO(52, 51, 67, 1);
+  static const Color whiteColor = Colors.white;
+  static const Color greyColor = Colors.grey;
+  static const Color errorColor = Colors.redAccent;
+  static const Color transparentColor = Colors.transparent;
+}

--- a/lib/core/theme/theme.dart
+++ b/lib/core/theme/theme.dart
@@ -15,7 +15,7 @@ class AppTheme {
       backgroundColor: AppPallete.backgroundColor,
     ),
     chipTheme: const ChipThemeData(
-      color: MaterialStatePropertyAll(
+      color: WidgetStatePropertyAll(
         AppPallete.backgroundColor,
       ),
       side: BorderSide.none,

--- a/lib/core/theme/theme.dart
+++ b/lib/core/theme/theme.dart
@@ -1,0 +1,31 @@
+import 'package:blogify/core/theme/app_pallete.dart';
+import 'package:flutter/material.dart';
+
+class AppTheme {
+  static _border([Color color = AppPallete.borderColor]) => OutlineInputBorder(
+        borderSide: BorderSide(
+          color: color,
+          width: 3,
+        ),
+        borderRadius: BorderRadius.circular(10),
+      );
+  static final darkThemeMode = ThemeData.dark().copyWith(
+    scaffoldBackgroundColor: AppPallete.backgroundColor,
+    appBarTheme: const AppBarTheme(
+      backgroundColor: AppPallete.backgroundColor,
+    ),
+    chipTheme: const ChipThemeData(
+      color: MaterialStatePropertyAll(
+        AppPallete.backgroundColor,
+      ),
+      side: BorderSide.none,
+    ),
+    inputDecorationTheme: InputDecorationTheme(
+      contentPadding: const EdgeInsets.all(27),
+      border: _border(),
+      enabledBorder: _border(),
+      focusedBorder: _border(AppPallete.gradient2),
+      errorBorder: _border(AppPallete.errorColor),
+    ),
+  );
+}

--- a/lib/features/auth/presentation/pages/sign_up_page.dart
+++ b/lib/features/auth/presentation/pages/sign_up_page.dart
@@ -1,0 +1,67 @@
+import 'package:blogify/core/theme/app_pallete.dart';
+import 'package:blogify/features/auth/presentation/widgets/auth_field.dart';
+import 'package:blogify/features/auth/presentation/widgets/auth_gradient_button.dart';
+import 'package:flutter/material.dart';
+
+class SignUpPage extends StatefulWidget {
+  const SignUpPage({super.key});
+
+  @override
+  State<SignUpPage> createState() => _SignUpPageState();
+}
+
+class _SignUpPageState extends State<SignUpPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SingleChildScrollView(
+        padding: EdgeInsets.symmetric(
+            vertical: MediaQuery.of(context).size.height * 0.3,
+            horizontal: MediaQuery.of(context).size.width * 0.04),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            const Text(
+              'Sign Up.',
+              style: TextStyle(
+                fontSize: 50,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 30),
+            const AuthField(
+              hintText: 'Name',
+            ),
+            const SizedBox(height: 15),
+            const AuthField(
+              hintText: 'Email',
+            ),
+            const SizedBox(height: 15),
+            const AuthField(
+              hintText: 'Password',
+              isObscureText: true,
+            ),
+            const SizedBox(height: 20),
+            AuthGradientButton(buttonText: 'Sign Up', onPressed: () {}),
+            const SizedBox(height: 20),
+            RichText(
+              text: TextSpan(
+                text: 'Already have an account? ',
+                style: Theme.of(context).textTheme.titleMedium,
+                children: [
+                  TextSpan(
+                    text: 'Sign In',
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          color: AppPallete.gradient2,
+                          fontWeight: FontWeight.bold,
+                        ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/presentation/widgets/auth_field.dart
+++ b/lib/features/auth/presentation/widgets/auth_field.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+class AuthField extends StatelessWidget {
+  final String hintText;
+  final TextEditingController? controller;
+  final bool isObscureText;
+  const AuthField({
+    super.key,
+    required this.hintText,
+      this.controller,
+    this.isObscureText = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      controller: controller,
+      decoration: InputDecoration(
+        hintText: hintText,
+      ),
+      validator: (value) {
+        if (value!.isEmpty) {
+          return "$hintText is missing!";
+        }
+        return null;
+      },
+      obscureText: isObscureText,
+    );
+  }
+}

--- a/lib/features/auth/presentation/widgets/auth_gradient_button.dart
+++ b/lib/features/auth/presentation/widgets/auth_gradient_button.dart
@@ -1,0 +1,45 @@
+import 'package:blogify/core/theme/app_pallete.dart';
+import 'package:flutter/material.dart';
+
+class AuthGradientButton extends StatelessWidget {
+  final String buttonText;
+  final VoidCallback onPressed;
+  const AuthGradientButton({
+    super.key,
+    required this.buttonText,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        gradient: const LinearGradient(
+          colors: [
+            AppPallete.gradient1,
+            AppPallete.gradient2,
+            // AppPallete.gradient3,
+          ],
+          begin: Alignment.bottomLeft,
+          end: Alignment.topRight,
+        ),
+        borderRadius: BorderRadius.circular(7),
+      ),
+      child: ElevatedButton(
+        onPressed: onPressed,
+        style: ElevatedButton.styleFrom(
+          fixedSize: const Size(395, 55),
+          backgroundColor: AppPallete.transparentColor,
+          shadowColor: AppPallete.transparentColor,
+        ),
+        child: Text(
+          buttonText,
+          style: const TextStyle(
+            fontSize: 17,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,5 @@
+import 'package:blogify/core/theme/theme.dart';
+import 'package:blogify/features/auth/presentation/pages/sign_up_page.dart';
 import 'package:flutter/material.dart';
 
 void main() {
@@ -10,8 +12,10 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
+    return MaterialApp(
+      theme: AppTheme.darkThemeMode,
       title: 'Blogify',
+      home: const SignUpPage(),
     );
   }
 }


### PR DESCRIPTION
This PR merges the latest development changes into the main branch, including:

- Introduction of `AuthField` widget for reusable form fields with validation.
- Implementation of `AuthGradientButton` widget featuring a gradient background.
- Addition of `SignUpPage` UI with fields for name, email, password, and a sign-up button.
  - Includes a rich text link for users to navigate to the sign-in page if they already have an account.

These updates enhance the user experience by providing a consistent and visually appealing sign-up interface. Ready to be merged into the main branch.
