### PR TITLE
feat: Add Sign-In Use Case and Integrate with AuthBloc

### DIFF
--- a/lib/core/service_locator/service_locator.dart
+++ b/lib/core/service_locator/service_locator.dart
@@ -1,5 +1,6 @@
 import 'package:blogify/features/auth/data/data_sources/remote_data_source.dart';
 import 'package:blogify/features/auth/data/repository/auth_rempository_impl.dart';
+import 'package:blogify/features/auth/domain/usecases/user_sign_in_usecase.dart';
 import 'package:blogify/features/auth/domain/usecases/user_sign_up_usecase.dart';
 import 'package:blogify/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:get_it/get_it.dart';
@@ -21,6 +22,10 @@ Future<void> setupServiceLocator() async {
 
   getIt.registerFactory<UserSignUpUseCase>(
       () => UserSignUpUseCase(authRepository: getIt<AuthRepositoryImpl>()));
-  getIt.registerLazySingleton<AuthBloc>(
-      () => AuthBloc(userSignUpUseCase: getIt<UserSignUpUseCase>()));
+  getIt.registerFactory<UserSignInUseCase>(
+      () => UserSignInUseCase(authRepository: getIt<AuthRepositoryImpl>()));
+
+  getIt.registerLazySingleton<AuthBloc>(() => AuthBloc(
+      userSignUpUseCase: getIt<UserSignUpUseCase>(),
+      userSignInUseCase: getIt<UserSignInUseCase>()));
 }

--- a/lib/features/auth/data/data_sources/remote_data_source.dart
+++ b/lib/features/auth/data/data_sources/remote_data_source.dart
@@ -6,7 +6,7 @@ import 'package:supabase_flutter/supabase_flutter.dart';
 abstract interface class RemoteDataSource {
   Future<Either<AppException, UserModel>> signUpWithEmailAndPassword(
       {required String name, required String email, required String password});
-  Future<Either<AppException, UserModel>> loginWithEmailAndPassword(
+  Future<Either<AppException, UserModel>> signInWithEmailAndPassword(
       {required String email, required String password});
 }
 
@@ -32,8 +32,18 @@ class RemoteDataSourceImpl implements RemoteDataSource {
   }
 
   @override
-  Future<Either<AppException, UserModel>> loginWithEmailAndPassword(
+  Future<Either<AppException, UserModel>> signInWithEmailAndPassword(
       {required String email, required String password}) async {
-    throw UnimplementedError();
+    try {
+      final authResponse = await supabaseClient.auth
+          .signInWithPassword(email: email, password: password);
+      return Right(UserModel.fromJson(authResponse.user!.toJson()));
+    } catch (e) {
+      if (e is AuthException) {
+        return Left(AppException.fromServerException(e.message));
+      } else {
+        return const Left(AppException());
+      }
+    }
   }
 }

--- a/lib/features/auth/data/repository/auth_rempository_impl.dart
+++ b/lib/features/auth/data/repository/auth_rempository_impl.dart
@@ -12,14 +12,14 @@ class AuthRepositoryImpl implements AuthRepository {
       {required String name,
       required String email,
       required String password}) async {
-   return await remoteDataSource.signUpWithEmailAndPassword(
+    return await remoteDataSource.signUpWithEmailAndPassword(
         name: name, email: email, password: password);
   }
 
   @override
-  Future<Either<AppException, UserEntity>> loginWithEmailAndPassword(
-      {required String email, required String password}) async{
-    return await remoteDataSource.loginWithEmailAndPassword(
+  Future<Either<AppException, UserEntity>> signInWithEmailAndPassword(
+      {required String email, required String password}) async {
+    return await remoteDataSource.signInWithEmailAndPassword(
         email: email, password: password);
   }
 }

--- a/lib/features/auth/domain/repository/auth_repository.dart
+++ b/lib/features/auth/domain/repository/auth_repository.dart
@@ -3,6 +3,8 @@ import 'package:blogify/features/auth/domain/entities/user_entity.dart';
 import 'package:dartz/dartz.dart';
 
 abstract interface class AuthRepository {
-  Future<Either<AppException, UserEntity>> signUpWithEmailAndPassword({required String name,required String email,required String password});
-  Future<Either<AppException,  UserEntity>> loginWithEmailAndPassword({required String email,required String password});
+  Future<Either<AppException, UserEntity>> signUpWithEmailAndPassword(
+      {required String name, required String email, required String password});
+  Future<Either<AppException, UserEntity>> signInWithEmailAndPassword(
+      {required String email, required String password});
 }

--- a/lib/features/auth/domain/usecases/user_sign_in_usecase.dart
+++ b/lib/features/auth/domain/usecases/user_sign_in_usecase.dart
@@ -1,0 +1,22 @@
+import 'package:blogify/core/common/usecase/usecase.dart';
+import 'package:blogify/core/error/exceptions.dart';
+import 'package:blogify/features/auth/domain/entities/user_entity.dart';
+import 'package:blogify/features/auth/domain/repository/auth_repository.dart';
+import 'package:dartz/dartz.dart';
+
+class UserSignInUseCase implements Usecase<UserEntity, UserSignInParams> {
+  final AuthRepository authRepository;
+  UserSignInUseCase({required this.authRepository});
+  @override
+  Future<Either<AppException, UserEntity>> call(UserSignInParams params) async {
+    return await authRepository.signInWithEmailAndPassword(
+        email: params.email, password: params.password);
+  }
+}
+
+class UserSignInParams {
+  final String email;
+  final String password;
+
+  UserSignInParams({required this.email, required this.password});
+}

--- a/lib/features/auth/presentation/bloc/auth_bloc.dart
+++ b/lib/features/auth/presentation/bloc/auth_bloc.dart
@@ -1,4 +1,5 @@
 import 'package:blogify/features/auth/domain/entities/user_entity.dart';
+import 'package:blogify/features/auth/domain/usecases/user_sign_in_usecase.dart';
 import 'package:blogify/features/auth/domain/usecases/user_sign_up_usecase.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -8,15 +9,31 @@ part 'auth_state.dart';
 
 class AuthBloc extends Bloc<AuthEvent, AuthState> {
   final UserSignUpUseCase _userSignUpUseCase;
-
-  AuthBloc({required UserSignUpUseCase userSignUpUseCase})
+  final UserSignInUseCase _userSignInUseCase;
+  AuthBloc(
+      {required UserSignUpUseCase userSignUpUseCase,
+      required UserSignInUseCase userSignInUseCase})
       : _userSignUpUseCase = userSignUpUseCase,
+        _userSignInUseCase = userSignInUseCase,
         super(AuthInitial()) {
     on<SignUpEvent>((event, emit) async {
       emit(AuthLoading());
 
       final result = await _userSignUpUseCase.call(UserSignUpParams(
           name: event.name, email: event.email, password: event.password));
+
+      result.fold((failure) {
+        emit(AuthError(failure.message));
+      }, (user) {
+        emit(AuthSuccess(user));
+      });
+    });
+
+    on<SignInEvent>((event, emit) async {
+      emit(AuthLoading());
+
+      final result = await _userSignInUseCase
+          .call(UserSignInParams(email: event.email, password: event.password));
 
       result.fold((failure) {
         emit(AuthError(failure.message));

--- a/lib/features/auth/presentation/bloc/auth_event.dart
+++ b/lib/features/auth/presentation/bloc/auth_event.dart
@@ -11,5 +11,16 @@ final class SignUpEvent extends AuthEvent {
   SignUpEvent({
     required this.name,
     required this.email,
-    required this.password,});
+    required this.password,
+  });
+}
+
+final class SignInEvent extends AuthEvent {
+  final String email;
+  final String password;
+
+  SignInEvent({
+    required this.email,
+    required this.password,
+  });
 }


### PR DESCRIPTION
- Implemented `UserSignInUseCase` for handling user sign-in logic.
- Updated `RemoteDataSourceImpl` to support sign-in with email and password using Supabase.
- Modified `AuthBloc` to handle both sign-up and sign-in events.
- Registered `UserSignInUseCase` and updated `AuthBloc` in the service locator with factory and lazy singleton patterns.
- Added `SignInEvent` to handle sign-in action within `AuthBloc`.