### PR TITLE
feat(blog): Add blog creation page with image picker and topic selection

### DIFF
--- a/lib/core/common/widgets/gradient_button.dart
+++ b/lib/core/common/widgets/gradient_button.dart
@@ -1,10 +1,10 @@
 import 'package:blogify/core/theme/app_pallete.dart';
 import 'package:flutter/material.dart';
 
-class AuthGradientButton extends StatelessWidget {
+class GradientButton extends StatelessWidget {
   final String buttonText;
   final VoidCallback onPressed;
-  const AuthGradientButton({
+  const GradientButton({
     super.key,
     required this.buttonText,
     required this.onPressed,

--- a/lib/core/constants/text_constants.dart
+++ b/lib/core/constants/text_constants.dart
@@ -1,0 +1,22 @@
+class TextConstants {
+  static const List<String> topics = [
+    'Technology',
+    'Business',
+    'Gaming',
+    'Books',
+    'Programming',
+    'Entertainment',
+    'Sports',
+    'Health',
+    'Science',
+    'World',
+    'Media',
+    'Fashion',
+    'Travel',
+    'Music',
+    'Food',
+    'Nature',
+  ];
+
+  static const noConnectionErrorMessage = 'Not connected to a network!';
+}

--- a/lib/core/routes/routes.dart
+++ b/lib/core/routes/routes.dart
@@ -1,21 +1,17 @@
 import 'package:blogify/features/auth/presentation/pages/login_page.dart';
 import 'package:blogify/features/auth/presentation/pages/sign_up_page.dart';
+import 'package:blogify/features/blog/presentation/pages/add_blog_page.dart';
+import 'package:blogify/features/blog/presentation/pages/blog_page.dart';
 import 'package:flutter/material.dart';
 
 class Routes {
-  static const String homePage = '/home_page';
   static const String signInPage = '/sign_in_page';
   static const String signUpPage = '/sign_up_page';
+  static const String blogPage = '/blog_page';
+  static const String addBlogPage = '/add_blog_page';
 
   static Route<dynamic> generateRoute(RouteSettings settings) {
     switch (settings.name) {
-      case homePage:
-        return MaterialPageRoute(
-          builder: (_) => Scaffold(
-            appBar: AppBar(title: const Text('Home')),
-            body: const Center(child: Text('Welcome to the Home Page!')),
-          ), // Replace with your actual HomePage widget
-        );
       case signInPage:
         return MaterialPageRoute(
           builder: (_) => const LoginPage(),
@@ -23,6 +19,14 @@ class Routes {
       case signUpPage:
         return MaterialPageRoute(
           builder: (_) => const SignUpPage(),
+        );
+      case blogPage:
+        return MaterialPageRoute(
+          builder: (_) => const BlogPage(),
+        );
+        case addBlogPage:
+        return MaterialPageRoute(
+          builder: (_) => const AddBlogPage(),
         );
       default:
         return MaterialPageRoute(

--- a/lib/core/utils/pick_image.dart
+++ b/lib/core/utils/pick_image.dart
@@ -1,0 +1,17 @@
+import 'dart:io';
+
+import 'package:image_picker/image_picker.dart';
+
+Future<File?> pickImage() async {
+  try {
+    final xFile = await ImagePicker().pickImage(
+      source: ImageSource.gallery,
+    );
+    if (xFile != null) {
+      return File(xFile.path);
+    }
+    return null;
+  } catch (e) {
+    return null;
+  }
+}

--- a/lib/features/auth/presentation/pages/login_page.dart
+++ b/lib/features/auth/presentation/pages/login_page.dart
@@ -1,3 +1,4 @@
+import 'package:blogify/core/common/widgets/gradient_button.dart';
 import 'package:blogify/core/common/widgets/loader.dart';
 import 'package:blogify/core/routes/routes.dart';
 import 'package:blogify/core/theme/app_pallete.dart';
@@ -5,7 +6,6 @@ import 'package:blogify/core/utils/show_snackbar.dart';
 import 'package:blogify/core/validators/validation.dart';
 import 'package:blogify/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:blogify/features/auth/presentation/widgets/auth_field.dart';
-import 'package:blogify/features/auth/presentation/widgets/auth_gradient_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -66,7 +66,7 @@ class _LoginPageState extends State<LoginPage> {
               BlocConsumer<AuthBloc, AuthState>(
                 listener: (context, state) {
                   if (state is AuthSuccess) {
-                    Navigator.pushReplacementNamed(context, Routes.homePage);
+                    Navigator.pushReplacementNamed(context, Routes.blogPage);
                   } else if (state is AuthError) {
                     showSnackBar(content: state.message, context: context);
                   }
@@ -75,7 +75,7 @@ class _LoginPageState extends State<LoginPage> {
                   if (state is AuthLoading) {
                     return const Loader();
                   } else {
-                    return AuthGradientButton(
+                    return GradientButton(
                         buttonText: 'Sign In',
                         onPressed: () async {
                           if (formKey.currentState!.validate()) {

--- a/lib/features/auth/presentation/pages/sign_up_page.dart
+++ b/lib/features/auth/presentation/pages/sign_up_page.dart
@@ -1,3 +1,4 @@
+import 'package:blogify/core/common/widgets/gradient_button.dart';
 import 'package:blogify/core/common/widgets/loader.dart';
 import 'package:blogify/core/routes/routes.dart';
 import 'package:blogify/core/theme/app_pallete.dart';
@@ -5,7 +6,6 @@ import 'package:blogify/core/utils/show_snackbar.dart';
 import 'package:blogify/core/validators/validation.dart';
 import 'package:blogify/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:blogify/features/auth/presentation/widgets/auth_field.dart';
-import 'package:blogify/features/auth/presentation/widgets/auth_gradient_button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -75,7 +75,7 @@ class _SignUpPageState extends State<SignUpPage> {
               BlocConsumer<AuthBloc, AuthState>(
                 listener: (context, state) {
                   if (state is AuthSuccess) {
-                    Navigator.pushReplacementNamed(context, Routes.homePage);
+                    Navigator.pushReplacementNamed(context, Routes.blogPage);
                   } else if (state is AuthError) {
                     showSnackBar(content: state.message, context: context);
                   }
@@ -84,7 +84,7 @@ class _SignUpPageState extends State<SignUpPage> {
                   if (state is AuthLoading) {
                     return const Loader();
                   } else {
-                    return AuthGradientButton(
+                    return GradientButton(
                         buttonText: 'Sign Up',
                         onPressed: () async {
                           if (formKey.currentState!.validate()) {

--- a/lib/features/blog/presentation/pages/add_blog_page.dart
+++ b/lib/features/blog/presentation/pages/add_blog_page.dart
@@ -1,0 +1,156 @@
+import 'dart:io';
+
+import 'package:blogify/core/common/widgets/gradient_button.dart';
+import 'package:blogify/core/constants/text_constants.dart';
+import 'package:blogify/core/theme/app_pallete.dart';
+import 'package:blogify/core/utils/pick_image.dart';
+import 'package:blogify/features/blog/presentation/widgets/blog_editor.dart';
+import 'package:dotted_border/dotted_border.dart';
+import 'package:flutter/material.dart';
+
+class AddBlogPage extends StatefulWidget {
+  const AddBlogPage({super.key});
+
+  @override
+  State<AddBlogPage> createState() => _AddBlogPageState();
+}
+
+class _AddBlogPageState extends State<AddBlogPage> {
+  final titleController = TextEditingController();
+  final contentController = TextEditingController();
+  final formKey = GlobalKey<FormState>();
+  List<String> selectedTopics = [];
+  File? image;
+  void selectImage() async {
+    final pickedImage = await pickImage();
+    if (pickedImage != null) {
+      setState(() {
+        image = pickedImage;
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    titleController.dispose();
+    contentController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          actions: [
+            IconButton(onPressed: () {}, icon: const Icon(Icons.done_rounded)),
+          ],
+        ),
+        body: SingleChildScrollView(
+          child: Padding(
+            padding: EdgeInsets.all(MediaQuery.of(context).size.width * 0.03),
+            child: Form(
+              key: formKey,
+              child: Column(
+                children: [
+                  image != null
+                      ? GestureDetector(
+                          onTap: selectImage,
+                          child: SizedBox(
+                            width: double.infinity,
+                            height: MediaQuery.of(context).size.height * 0.3,
+                            child: ClipRRect(
+                              borderRadius: BorderRadius.circular(10),
+                              child: Image.file(
+                                image!,
+                                fit: BoxFit.cover,
+                              ),
+                            ),
+                          ),
+                        )
+                      : GestureDetector(
+                          onTap: () {
+                            selectImage();
+                          },
+                          child: DottedBorder(
+                            color: AppPallete.borderColor,
+                            dashPattern: const [10, 4],
+                            radius: const Radius.circular(10),
+                            borderType: BorderType.RRect,
+                            strokeCap: StrokeCap.round,
+                            child: SizedBox(
+                              height: MediaQuery.of(context).size.height * 0.3,
+                              width: double.infinity,
+                              child: const Column(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: [
+                                  Icon(
+                                    Icons.folder_open,
+                                    size: 40,
+                                  ),
+                                  SizedBox(height: 15),
+                                  Text(
+                                    'Select your image',
+                                    style: TextStyle(
+                                      fontSize: 15,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ),
+                        ),
+                  const SizedBox(height: 20),
+                  SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: Row(
+                      children: TextConstants.topics
+                          .map(
+                            (e) => Padding(
+                              padding:   EdgeInsets.all(MediaQuery.of(context).size.width * 0.01),
+                              child: GestureDetector(
+                                onTap: () {
+                                  if (selectedTopics.contains(e)) {
+                                    selectedTopics.remove(e);
+                                  } else {
+                                    selectedTopics.add(e);
+                                  }
+                                  setState(() {});
+                                },
+                                child: Chip(
+                                  label: Text(e),
+                                  color: selectedTopics.contains(e)
+                                      ? const WidgetStatePropertyAll(
+                                          AppPallete.gradient1,
+                                        )
+                                      : null,
+                                  side: selectedTopics.contains(e)
+                                      ? null
+                                      : const BorderSide(
+                                          color: AppPallete.borderColor,
+                                        ),
+                                ),
+                              ),
+                            ),
+                          )
+                          .toList(),
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  BlogEditor(
+                    controller: titleController,
+                    hintText: 'Blog title',
+                  ),
+                  const SizedBox(height: 10),
+                  BlogEditor(
+                    controller: contentController,
+                    hintText: 'Blog content',
+                  ),
+                  const SizedBox(height: 20),
+                GradientButton(buttonText: 'Add Blog', onPressed: (){}),
+                ],
+              ),
+            ),
+          ),
+        ));
+  }
+}

--- a/lib/features/blog/presentation/pages/blog_page.dart
+++ b/lib/features/blog/presentation/pages/blog_page.dart
@@ -1,0 +1,24 @@
+import 'package:blogify/core/routes/routes.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class BlogPage extends StatelessWidget {
+  const BlogPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Blogify'),
+        actions: [
+          IconButton(
+            onPressed: () {
+              Navigator.pushNamed(context, Routes.addBlogPage);
+            },
+            icon: const Icon(CupertinoIcons.add_circled),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/blog/presentation/widgets/blog_editor.dart
+++ b/lib/features/blog/presentation/widgets/blog_editor.dart
@@ -1,0 +1,26 @@
+import 'package:blogify/core/validators/validation.dart';
+import 'package:flutter/material.dart';
+
+class BlogEditor extends StatelessWidget {
+  final TextEditingController controller;
+  final String hintText;
+  const BlogEditor({
+    super.key,
+    required this.controller,
+    required this.hintText,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return TextFormField(
+      controller: controller,
+      decoration: InputDecoration(
+        hintText: hintText,
+      ),
+      maxLines: null,
+      validator: (value) {
+        return FieldValidator.validateEmpty(value, hintText);
+      },
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -113,6 +113,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.10.1"
+  dotted_border:
+    dependency: "direct main"
+    description:
+      name: dotted_border
+      sha256: "108837e11848ca776c53b30bc870086f84b62ed6e01c503ed976e8f8c7df9c04"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   equatable:
     dependency: "direct main"
     description:
@@ -424,6 +432,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.0"
+  path_drawing:
+    dependency: transitive
+    description:
+      name: path_drawing
+      sha256: bbb1934c0cbb03091af082a6389ca2080345291ef07a5fa6d6e078ba8682f977
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      sha256: e3e67b1629e6f7e8100b367d3db6ba6af4b1f0bb80f64db18ef1fbabd2fa9ccf
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   path_provider:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   app_links: ^6.2.0
   cupertino_icons: ^1.0.8
   dartz: ^0.10.1
+  dotted_border: ^2.1.0
   equatable: ^2.0.5
   flutter:
     sdk: flutter


### PR DESCRIPTION
- Implemented `AddBlogPage` with a form for adding a blog post.
- Integrated image picker functionality for blog cover images.
- Added topic selection using chips for better categorization of blog posts.
- Created utility function `pickImage` for selecting images from the gallery.
- Added `TextConstants` for predefined topics and error messages.
- Updated `BlogPage` with a navigation to the `AddBlogPage`.
- Added `BlogEditor` widget for better text input handling.